### PR TITLE
feat: add multi-currency support to Promotional Bounties

### DIFF
--- a/client/src/lib/promotional-bounties-api.ts
+++ b/client/src/lib/promotional-bounties-api.ts
@@ -12,6 +12,7 @@ export interface PromotionalBounty {
   requiredDeliverable: string | null;
   rewardAmount: string;
   rewardType: "PER_SUBMISSION" | "POOL" | "TIERED";
+  rewardCurrency: "XDC" | "ROXN" | "USDC";
   maxSubmissions: number | null;
   totalRewardPool: string | null;
   campaignId: string | null;
@@ -43,6 +44,7 @@ export interface CreateBountyInput {
   requiredDeliverable: string;
   rewardAmount: string;
   rewardType?: "PER_SUBMISSION" | "POOL" | "TIERED";
+  rewardCurrency?: "XDC" | "ROXN" | "USDC";
   maxSubmissions?: number;
   totalRewardPool?: string;
   expiresAt?: string;

--- a/server/routes/promotionalBounties.ts
+++ b/server/routes/promotionalBounties.ts
@@ -301,6 +301,7 @@ router.post('/bounties', requireAuth, requireClient, csrfProtection, createBount
       requiredDeliverable: validatedData.requiredDeliverable,
       rewardAmount: validatedData.rewardAmount,
       rewardType: validatedData.rewardType,
+      rewardCurrency: validatedData.rewardCurrency || 'XDC',
       maxSubmissions: validatedData.maxSubmissions,
       totalRewardPool: validatedData.totalRewardPool,
       expiresAt: validatedData.expiresAt ? new Date(validatedData.expiresAt) : null,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -539,6 +539,7 @@ export const promotionalBounties = pgTable("promotional_bounties", {
   requiredDeliverable: text("required_deliverable"),
   rewardAmount: decimal("reward_amount", { precision: 18, scale: 8 }).notNull(),
   rewardType: text("reward_type", { enum: ["PER_SUBMISSION", "POOL", "TIERED"] }).notNull().default("PER_SUBMISSION"),
+  rewardCurrency: text("reward_currency", { enum: ["XDC", "ROXN", "USDC"] }).notNull().default("XDC"),
   maxSubmissions: integer("max_submissions"),
   totalRewardPool: decimal("total_reward_pool", { precision: 18, scale: 8 }),
   campaignId: text("campaign_id"),


### PR DESCRIPTION
Fixes #46 

I fixed this issue by adding the `reward_currency` column to the `promotional_bounties` database schema and updating the backend routes to accept `rewardCurrency` (XDC, ROXN, USDC) during bounty creation.

Bounty Wallet: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now specify a reward currency when creating promotional bounties. Supported currencies include XDC, ROXN, and USDC, with XDC as the default option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Roxonn-FutureTech/Roxonn-Platform/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->