### PR TITLE
Validate promotional proof links by channel

### DIFF
--- a/client/src/pages/promotional-bounties-create-page.tsx
+++ b/client/src/pages/promotional-bounties-create-page.tsx
@@ -19,6 +19,7 @@ const PROMOTIONAL_CHANNELS = [
   "LinkedIn",
   "Facebook",
   "Instagram",
+  "TikTok",
   "YouTube",
   "Blog",
   "Forum",

--- a/client/src/pages/promotional-bounties-detail-page.tsx
+++ b/client/src/pages/promotional-bounties-detail-page.tsx
@@ -12,6 +12,11 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { promotionalBountiesAPI, type PromotionalBounty, type CreateSubmissionInput } from "@/lib/promotional-bounties-api";
+import {
+  getSupportedProofLinkHint,
+  validateProofLinkForChannels,
+  validateProofLinksForChannels,
+} from "@shared/promotionalUrlValidation";
 import { ArrowLeft, Coins, Calendar, Users, CheckCircle2, XCircle, Plus, X, ExternalLink } from "lucide-react";
 import { format } from "date-fns";
 
@@ -95,6 +100,12 @@ export default function PromotionalBountiesDetailPage() {
     const validLinks = submissionForm.proofLinks.filter((link) => link.trim());
     if (validLinks.length === 0) {
       setError("Please provide at least one proof link");
+      return;
+    }
+
+    const proofLinkValidation = validateProofLinksForChannels(validLinks, bounty?.promotionalChannels ?? []);
+    if (!proofLinkValidation.valid) {
+      setError(proofLinkValidation.message || "Invalid proof link for the selected promotional channel");
       return;
     }
 
@@ -189,26 +200,36 @@ export default function PromotionalBountiesDetailPage() {
                     <div className="space-y-2">
                       <Label>Proof Links *</Label>
                       {submissionForm.proofLinks.map((link, index) => (
-                        <div key={index} className="flex gap-2">
-                          <Input
-                            type="url"
-                            value={link}
-                            onChange={(e) => handleLinkChange(index, e.target.value)}
-                            placeholder="https://twitter.com/..."
-                            required={index === 0}
-                          />
-                          {submissionForm.proofLinks.length > 1 && (
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="icon"
-                              onClick={() => handleRemoveLink(index)}
-                            >
-                              <X className="h-4 w-4" />
-                            </Button>
+                        <div key={index} className="space-y-1">
+                          <div className="flex gap-2">
+                            <Input
+                              type="url"
+                              value={link}
+                              onChange={(e) => handleLinkChange(index, e.target.value)}
+                              placeholder="https://twitter.com/..."
+                              required={index === 0}
+                            />
+                            {submissionForm.proofLinks.length > 1 && (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                onClick={() => handleRemoveLink(index)}
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            )}
+                          </div>
+                          {link.trim() && !validateProofLinkForChannels(link, bounty.promotionalChannels).valid && (
+                            <p className="text-sm text-red-500">
+                              {validateProofLinkForChannels(link, bounty.promotionalChannels).message}
+                            </p>
                           )}
                         </div>
                       ))}
+                      <p className="text-sm text-muted-foreground">
+                        {getSupportedProofLinkHint(bounty.promotionalChannels)}
+                      </p>
                       <Button type="button" variant="outline" onClick={handleAddLink} className="w-full">
                         <Plus className="mr-2 h-4 w-4" />
                         Add Another Link

--- a/client/src/pages/promotional-bounties-detail-page.tsx
+++ b/client/src/pages/promotional-bounties-detail-page.tsx
@@ -12,6 +12,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { promotionalBountiesAPI, type PromotionalBounty, type CreateSubmissionInput } from "@/lib/promotional-bounties-api";
+import { cn } from "@/lib/utils";
 import {
   getSupportedProofLinkHint,
   validateProofLinkForChannels,
@@ -199,34 +200,52 @@ export default function PromotionalBountiesDetailPage() {
                     )}
                     <div className="space-y-2">
                       <Label>Proof Links *</Label>
-                      {submissionForm.proofLinks.map((link, index) => (
-                        <div key={index} className="space-y-1">
-                          <div className="flex gap-2">
-                            <Input
-                              type="url"
-                              value={link}
-                              onChange={(e) => handleLinkChange(index, e.target.value)}
-                              placeholder="https://twitter.com/..."
-                              required={index === 0}
-                            />
-                            {submissionForm.proofLinks.length > 1 && (
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="icon"
-                                onClick={() => handleRemoveLink(index)}
-                              >
-                                <X className="h-4 w-4" />
-                              </Button>
+                      {submissionForm.proofLinks.map((link, index) => {
+                        const validation = link.trim()
+                          ? validateProofLinkForChannels(link, bounty.promotionalChannels)
+                          : null;
+
+                        return (
+                          <div key={index} className="space-y-1">
+                            <div className="flex gap-2">
+                              <div className="relative flex-1">
+                                <Input
+                                  type="url"
+                                  value={link}
+                                  onChange={(e) => handleLinkChange(index, e.target.value)}
+                                  placeholder="https://twitter.com/..."
+                                  required={index === 0}
+                                  className={cn(
+                                    validation?.valid && "border-green-500 pr-9 focus-visible:ring-green-500",
+                                    validation && !validation.valid && "border-red-500 pr-9 focus-visible:ring-red-500"
+                                  )}
+                                />
+                                {validation?.valid && (
+                                  <CheckCircle2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-green-500" />
+                                )}
+                                {validation && !validation.valid && (
+                                  <XCircle className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-red-500" />
+                                )}
+                              </div>
+                              {submissionForm.proofLinks.length > 1 && (
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="icon"
+                                  onClick={() => handleRemoveLink(index)}
+                                >
+                                  <X className="h-4 w-4" />
+                                </Button>
+                              )}
+                            </div>
+                            {validation && !validation.valid && (
+                              <p className="text-sm text-red-500">
+                                {validation.message}
+                              </p>
                             )}
                           </div>
-                          {link.trim() && !validateProofLinkForChannels(link, bounty.promotionalChannels).valid && (
-                            <p className="text-sm text-red-500">
-                              {validateProofLinkForChannels(link, bounty.promotionalChannels).message}
-                            </p>
-                          )}
-                        </div>
-                      ))}
+                        );
+                      })}
                       <p className="text-sm text-muted-foreground">
                         {getSupportedProofLinkHint(bounty.promotionalChannels)}
                       </p>

--- a/server/routes/__tests__/promotionalBounties.test.ts
+++ b/server/routes/__tests__/promotionalBounties.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import express from 'express';
+import request from 'supertest';
+import { db } from '../../db';
+import promotionalBountiesRoutes from '../promotionalBounties';
+
+vi.mock('../../db', () => ({
+  db: {
+    transaction: vi.fn(),
+  },
+  users: {},
+}));
+
+vi.mock('../../auth', () => ({
+  requireAuth: (req: Request, _res: Response, next: NextFunction) => {
+    (req as any).user = { id: 123, role: 'contributor' };
+    next();
+  },
+  requireDeveloper: (_req: Request, _res: Response, next: NextFunction) => next(),
+  requireClient: (_req: Request, _res: Response, next: NextFunction) => next(),
+  csrfProtection: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock('../../utils', () => ({
+  log: vi.fn(),
+}));
+
+describe('Promotional bounty routes', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/api/promotional', promotionalBountiesRoutes);
+  });
+
+  it('rejects submission proof links that do not match the bounty channel', async () => {
+    vi.mocked(db.transaction).mockImplementation(async (callback: any) => {
+      const tx = {
+        execute: vi.fn().mockResolvedValue({
+          rows: [{
+            id: 1,
+            status: 'ACTIVE',
+            promotional_channels: JSON.stringify(['Twitter']),
+            expires_at: null,
+            max_submissions: null,
+          }],
+        }),
+      };
+
+      return callback(tx);
+    });
+
+    const response = await request(app)
+      .post('/api/promotional/submissions')
+      .send({
+        bountyId: 1,
+        proofLinks: ['https://youtube.com/watch?v=abc'],
+        description: 'Wrong channel proof link',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('twitter.com');
+  });
+});

--- a/server/routes/promotionalBounties.ts
+++ b/server/routes/promotionalBounties.ts
@@ -12,6 +12,7 @@ import {
   type CreatePromotionalBountyInput,
   type CreatePromotionalSubmissionInput,
 } from '../../shared/schema';
+import { validateProofLinksForChannels } from '../../shared/promotionalUrlValidation';
 import { log } from '../utils';
 import rateLimit from 'express-rate-limit';
 
@@ -95,6 +96,25 @@ const transformSubmission = (submission: any) => {
     }
   }
   return submission;
+};
+
+const parseChannelList = (channels: unknown): string[] => {
+  if (Array.isArray(channels)) {
+    return channels.filter((channel): channel is string => typeof channel === 'string');
+  }
+
+  if (typeof channels === 'string') {
+    try {
+      const parsed = JSON.parse(channels);
+      return Array.isArray(parsed)
+        ? parsed.filter((channel): channel is string => typeof channel === 'string')
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
 };
 
 // Get user's registered repos
@@ -536,6 +556,15 @@ router.post('/submissions', requireAuth, requireDeveloper, csrfProtection, submi
       
       if (lockedBounty.expires_at && new Date(lockedBounty.expires_at) < new Date()) {
         throw new BusinessError('Bounty has expired', 400);
+      }
+
+      const promotionalChannels = parseChannelList(lockedBounty.promotional_channels);
+      const proofLinkValidation = validateProofLinksForChannels(
+        validatedData.proofLinks,
+        promotionalChannels
+      );
+      if (!proofLinkValidation.valid) {
+        throw new BusinessError(proofLinkValidation.message || 'Invalid proof link for selected channel', 400);
       }
       // Check for existing submission from this user
       const existingSubmission = await tx

--- a/shared/promotionalUrlValidation.ts
+++ b/shared/promotionalUrlValidation.ts
@@ -1,0 +1,95 @@
+export type PromotionalUrlValidationResult = {
+  valid: boolean;
+  message?: string;
+};
+
+const CHANNEL_DOMAINS: Record<string, string[]> = {
+  twitter: ["twitter.com", "x.com"],
+  "twitter/x": ["twitter.com", "x.com"],
+  x: ["twitter.com", "x.com"],
+  linkedin: ["linkedin.com"],
+  youtube: ["youtube.com", "youtu.be"],
+  instagram: ["instagram.com"],
+  tiktok: ["tiktok.com"],
+  facebook: ["facebook.com"],
+};
+
+const GENERIC_HTTPS_CHANNELS = new Set(["blog", "forum", "other"]);
+
+function normalizeChannel(channel: string): string {
+  return channel.trim().toLowerCase();
+}
+
+function hostnameMatches(hostname: string, allowedDomain: string): boolean {
+  return hostname === allowedDomain || hostname.endsWith(`.${allowedDomain}`);
+}
+
+export function getSupportedProofLinkHint(channels: string[]): string {
+  const domains = channels
+    .flatMap((channel) => CHANNEL_DOMAINS[normalizeChannel(channel)] ?? [])
+    .filter((domain, index, all) => all.indexOf(domain) === index);
+
+  if (channels.some((channel) => GENERIC_HTTPS_CHANNELS.has(normalizeChannel(channel)))) {
+    return "Use a valid HTTPS URL for the selected channel.";
+  }
+
+  if (domains.length === 0) {
+    return "Use a valid HTTP or HTTPS proof link.";
+  }
+
+  return `Use a valid proof link from: ${domains.join(", ")}.`;
+}
+
+export function validateProofLinkForChannels(
+  proofLink: string,
+  channels: string[]
+): PromotionalUrlValidationResult {
+  let parsed: URL;
+  try {
+    parsed = new URL(proofLink.trim());
+  } catch {
+    return { valid: false, message: "Proof link must be a valid URL." };
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return { valid: false, message: "Only HTTP and HTTPS proof links are allowed." };
+  }
+
+  const normalizedChannels = channels.map(normalizeChannel);
+  if (normalizedChannels.some((channel) => GENERIC_HTTPS_CHANNELS.has(channel))) {
+    if (parsed.protocol !== "https:") {
+      return { valid: false, message: "Blog, forum, and other proof links must use HTTPS." };
+    }
+    return { valid: true };
+  }
+
+  const allowedDomains = normalizedChannels.flatMap((channel) => CHANNEL_DOMAINS[channel] ?? []);
+  if (allowedDomains.length === 0) {
+    return { valid: true };
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  const valid = allowedDomains.some((domain) => hostnameMatches(hostname, domain));
+  if (!valid) {
+    return {
+      valid: false,
+      message: getSupportedProofLinkHint(channels),
+    };
+  }
+
+  return { valid: true };
+}
+
+export function validateProofLinksForChannels(
+  proofLinks: string[],
+  channels: string[]
+): PromotionalUrlValidationResult {
+  for (const proofLink of proofLinks) {
+    const result = validateProofLinkForChannels(proofLink, channels);
+    if (!result.valid) {
+      return result;
+    }
+  }
+
+  return { valid: true };
+}

--- a/shared/promotionalUrlValidation.ts
+++ b/shared/promotionalUrlValidation.ts
@@ -29,6 +29,11 @@ export function getSupportedProofLinkHint(channels: string[]): string {
     .flatMap((channel) => CHANNEL_DOMAINS[normalizeChannel(channel)] ?? [])
     .filter((domain, index, all) => all.indexOf(domain) === index);
   const hasGenericChannel = channels.some((channel) => GENERIC_HTTPS_CHANNELS.has(normalizeChannel(channel)));
+  const hasRecognizedChannel = hasGenericChannel || domains.length > 0;
+
+  if (!hasRecognizedChannel) {
+    return "No recognized promotional channels were provided.";
+  }
 
   if (hasGenericChannel && domains.length > 0) {
     return `Use HTTPS for Blog, Forum, or Other links, or a valid proof link from: ${domains.join(", ")}.`;
@@ -39,7 +44,7 @@ export function getSupportedProofLinkHint(channels: string[]): string {
   }
 
   if (domains.length === 0) {
-    return "Use a valid HTTP or HTTPS proof link.";
+    return "No recognized promotional channels were provided.";
   }
 
   return `Use a valid proof link from: ${domains.join(", ")}.`;
@@ -65,8 +70,8 @@ export function validateProofLinkForChannels(
   const allowedDomains = normalizedChannels.flatMap((channel) => CHANNEL_DOMAINS[channel] ?? []);
   const hasRecognizedChannel = hasGenericChannel || allowedDomains.length > 0;
 
-  if (normalizedChannels.length > 0 && !hasRecognizedChannel) {
-    return { valid: false, message: "Unsupported promotional channel." };
+  if (!hasRecognizedChannel) {
+    return { valid: false, message: "No recognized promotional channels were provided." };
   }
 
   if (hasGenericChannel && parsed.protocol === "https:") {

--- a/shared/promotionalUrlValidation.ts
+++ b/shared/promotionalUrlValidation.ts
@@ -28,8 +28,13 @@ export function getSupportedProofLinkHint(channels: string[]): string {
   const domains = channels
     .flatMap((channel) => CHANNEL_DOMAINS[normalizeChannel(channel)] ?? [])
     .filter((domain, index, all) => all.indexOf(domain) === index);
+  const hasGenericChannel = channels.some((channel) => GENERIC_HTTPS_CHANNELS.has(normalizeChannel(channel)));
 
-  if (channels.some((channel) => GENERIC_HTTPS_CHANNELS.has(normalizeChannel(channel)))) {
+  if (hasGenericChannel && domains.length > 0) {
+    return `Use HTTPS for Blog, Forum, or Other links, or a valid proof link from: ${domains.join(", ")}.`;
+  }
+
+  if (hasGenericChannel) {
     return "Use a valid HTTPS URL for the selected channel.";
   }
 
@@ -56,15 +61,22 @@ export function validateProofLinkForChannels(
   }
 
   const normalizedChannels = channels.map(normalizeChannel);
-  if (normalizedChannels.some((channel) => GENERIC_HTTPS_CHANNELS.has(channel))) {
-    if (parsed.protocol !== "https:") {
-      return { valid: false, message: "Blog, forum, and other proof links must use HTTPS." };
-    }
+  const hasGenericChannel = normalizedChannels.some((channel) => GENERIC_HTTPS_CHANNELS.has(channel));
+  const allowedDomains = normalizedChannels.flatMap((channel) => CHANNEL_DOMAINS[channel] ?? []);
+  const hasRecognizedChannel = hasGenericChannel || allowedDomains.length > 0;
+
+  if (normalizedChannels.length > 0 && !hasRecognizedChannel) {
+    return { valid: false, message: "Unsupported promotional channel." };
+  }
+
+  if (hasGenericChannel && parsed.protocol === "https:") {
     return { valid: true };
   }
 
-  const allowedDomains = normalizedChannels.flatMap((channel) => CHANNEL_DOMAINS[channel] ?? []);
   if (allowedDomains.length === 0) {
+    if (hasGenericChannel) {
+      return { valid: false, message: "Blog, forum, and other proof links must use HTTPS." };
+    }
     return { valid: true };
   }
 
@@ -73,7 +85,9 @@ export function validateProofLinkForChannels(
   if (!valid) {
     return {
       valid: false,
-      message: getSupportedProofLinkHint(channels),
+      message: hasGenericChannel && parsed.protocol !== "https:"
+        ? "Blog, forum, and other proof links must use HTTPS."
+        : getSupportedProofLinkHint(channels),
     };
   }
 

--- a/tests/promotionalUrlValidation.test.ts
+++ b/tests/promotionalUrlValidation.test.ts
@@ -33,8 +33,22 @@ describe("promotional proof link validation", () => {
     expect(result.valid).toBe(false);
   });
 
+  it("accepts links when any selected channel matches mixed generic and social channels", () => {
+    expect(validateProofLinkForChannels("http://x.com/roxonn/status/1", ["Twitter", "Blog"]).valid).toBe(true);
+    expect(validateProofLinkForChannels("https://example.com/post", ["Twitter", "Blog"]).valid).toBe(true);
+    expect(validateProofLinkForChannels("http://example.com/post", ["Twitter", "Blog"]).valid).toBe(false);
+  });
+
+  it("rejects unsupported channel names instead of bypassing hostname validation", () => {
+    const result = validateProofLinkForChannels("https://example.com/post", ["Newsletter"]);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toBe("Unsupported promotional channel.");
+  });
+
   it("returns helpful supported-domain hints", () => {
     expect(getSupportedProofLinkHint(["Twitter", "YouTube"])).toContain("twitter.com");
     expect(getSupportedProofLinkHint(["Twitter", "YouTube"])).toContain("youtube.com");
+    expect(getSupportedProofLinkHint(["Twitter", "Blog"])).toContain("Use HTTPS for Blog");
   });
 });

--- a/tests/promotionalUrlValidation.test.ts
+++ b/tests/promotionalUrlValidation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSupportedProofLinkHint,
+  validateProofLinkForChannels,
+  validateProofLinksForChannels,
+} from "../shared/promotionalUrlValidation";
+
+describe("promotional proof link validation", () => {
+  it("accepts proof links from selected social channels", () => {
+    expect(validateProofLinkForChannels("https://x.com/roxonn/status/1", ["Twitter"]).valid).toBe(true);
+    expect(validateProofLinkForChannels("https://www.linkedin.com/posts/roxonn", ["LinkedIn"]).valid).toBe(true);
+    expect(validateProofLinkForChannels("https://youtu.be/demo", ["YouTube"]).valid).toBe(true);
+    expect(validateProofLinkForChannels("https://www.tiktok.com/@roxonn/video/1", ["TikTok"]).valid).toBe(true);
+  });
+
+  it("rejects URLs that do not match the selected channel hostname", () => {
+    expect(validateProofLinkForChannels("https://twitter.com.evil.test/post", ["Twitter"]).valid).toBe(false);
+    expect(validateProofLinkForChannels("https://linkedin.com.evil.test/post", ["LinkedIn"]).valid).toBe(false);
+    expect(validateProofLinkForChannels("https://youtube.com.evil.test/watch", ["YouTube"]).valid).toBe(false);
+  });
+
+  it("requires HTTPS for generic promotional channels", () => {
+    expect(validateProofLinkForChannels("https://example.com/post", ["Blog"]).valid).toBe(true);
+    expect(validateProofLinkForChannels("http://example.com/post", ["Blog"]).valid).toBe(false);
+  });
+
+  it("validates all submitted proof links", () => {
+    const result = validateProofLinksForChannels(
+      ["https://x.com/roxonn/status/1", "https://facebook.com.evil.test/post"],
+      ["Twitter", "Facebook"]
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns helpful supported-domain hints", () => {
+    expect(getSupportedProofLinkHint(["Twitter", "YouTube"])).toContain("twitter.com");
+    expect(getSupportedProofLinkHint(["Twitter", "YouTube"])).toContain("youtube.com");
+  });
+});

--- a/tests/promotionalUrlValidation.test.ts
+++ b/tests/promotionalUrlValidation.test.ts
@@ -43,12 +43,20 @@ describe("promotional proof link validation", () => {
     const result = validateProofLinkForChannels("https://example.com/post", ["Newsletter"]);
 
     expect(result.valid).toBe(false);
-    expect(result.message).toBe("Unsupported promotional channel.");
+    expect(result.message).toBe("No recognized promotional channels were provided.");
+  });
+
+  it("rejects empty channel lists instead of accepting arbitrary proof links", () => {
+    const result = validateProofLinkForChannels("https://example.com/post", []);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toBe("No recognized promotional channels were provided.");
   });
 
   it("returns helpful supported-domain hints", () => {
     expect(getSupportedProofLinkHint(["Twitter", "YouTube"])).toContain("twitter.com");
     expect(getSupportedProofLinkHint(["Twitter", "YouTube"])).toContain("youtube.com");
     expect(getSupportedProofLinkHint(["Twitter", "Blog"])).toContain("Use HTTPS for Blog");
+    expect(getSupportedProofLinkHint(["Newsletter"])).toContain("No recognized promotional channels");
   });
 });


### PR DESCRIPTION
Fixes #49

## Summary
- add shared proof-link validation for promotional bounty channels
- enforce channel-specific proof URL checks on submission in the API
- show client-side validation feedback and supported-domain hints before submit
- include TikTok in the available promotional channels

## Validation covered
- Twitter/X: 	witter.com, x.com
- LinkedIn: linkedin.com
- YouTube: youtube.com, youtu.be
- Instagram: instagram.com
- TikTok: 	iktok.com
- Facebook: acebook.com
- Blog/Forum/Other: valid HTTPS URL

The hostname check accepts exact domains and real subdomains, but rejects lookalikes such as 	witter.com.evil.test.

## Tests
- 
pm.cmd exec vitest -- run tests/promotionalUrlValidation.test.ts passed: 5 tests
- git diff --check passed; only Windows line-ending warnings were printed
- 
pm.cmd run check was attempted, but the repository currently has unrelated TypeScript failures in existing files such as onboarding, blockchain, Azure media, GitHub handlers, and existing promotional bounty routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TikTok as a selectable promotional channel option.
  * Implemented proof link validation that enforces channel-specific URL requirements when submitting promotional bounty work.
  * Added helpful guidance messages showing users which proof links are valid for their selected channels.

* **Tests**
  * Added comprehensive tests for promotional proof link validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->